### PR TITLE
ログイン後の遷移先変更、route / を定義

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -39,6 +39,9 @@ class LoginController extends Controller
     }
     protected function loggedOut()
     {
-        return redirect(route('top.index'));
+        return redirect(route('index'));
     }
+    protected function redirectTo() {
+      return route('index');
+   }
 }

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -1,7 +1,7 @@
 <header>
     <div class="gloval_fixed_menu">
         <div class="gloval_fixed_menu_inner">
-            <a href="{{ route('top.index') }}">photoshare</a>
+            <a href="{{ route('index') }}">photoshare</a>
             <form class="form-box" action="{{ route('tag_search.index') }}" method="get">
                 <input classclass="form-input" type="text" name="tags">
                 <button class="form-button"><img src="{{asset('/SystemImage/top_search_icon.png')}}" width="20px" height="20px"></button>
@@ -12,9 +12,6 @@
                 <label for="menu-btn-check" class="menu-btn"><span></span></label>
                 <div class="menu-content">
                     <ul>
-                        <li>
-                            <a href="{{ route('top.index') }}">topページ</a>
-                        </li>
                         @if (Auth::check() === true)
                         <li>
                             <a href="{{ route('users.show',['user'=>Auth::user()]) }}">プロフィール</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 //topページ
-Route::resource('top',TopController::class)->only([
+Route::resource('/',TopController::class)->only([
     'index'
 ]);
 


### PR DESCRIPTION
トッページのURL名を"/"へ変更
ログイン後homeではなく、/へ遷移するように変更。

/へのリンクがあるbladeを修正。
ヘッダーのハンバーガーメニューに不要な/へのリンクがあったので削除
![image](https://user-images.githubusercontent.com/73060776/108059256-90b43080-7098-11eb-98c2-2e85001bd603.png)
